### PR TITLE
Send options to extractStrings

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ AngularGetTextPlugin.prototype.apply = function(compiler) {
     }
 
     if (options.extractStrings) {
-      var extractor = new Extractor();
+      var extractor = new Extractor(options.extractStrings);
 
       const filePaths = glob.sync(options.extractStrings.input)
       filePaths.forEach( (fileName) => {


### PR DESCRIPTION
The extractor has many options that were not being passed from the webpack plugin (for example, `markerNames`). This pull request sends the `extractStrings` object to the `Extractor` constructor in order to pass along these options.