### PR TITLE
Allow splitting of language files

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,21 @@ AngularGetTextPlugin.prototype.apply = function(compiler) {
       const results = compile(options.compileTranslations);
       results.forEach( (result) => {
         const { fileName, content } = result;
-        const outPath = path.join(options.compileTranslations.outputFolder, fileName);
+
+        var realfileName;
+
+        if (options.compileTranslations.compileCatalog) {
+            var language = content[2] + content[3];
+
+            realfileName = fileName.split('.');
+            realfileName.splice(1, 0, language);
+            realfileName = realfileName.join('.');
+        } else {
+            realfileName = fileName;
+        }
+
+        const outPath = path.join(options.compileTranslations.outputFolder, realfileName);
+        
         compilation.assets[outPath] = {
           source: function() {
             return content;


### PR DESCRIPTION
All you need to do is add a 'compileCatalog' bool set to true to your webpack config like this:
new AngularGetTextPlugin({
   compileTranslations: {
        // Adapt as necessary, this includes all languages in a default LC_MESSAGES catalog
        input: '../locale/**/LC_MESSAGES/frontend.po', 
        outputFolder: 'l10n',
        format: 'json',
        compileCatalog: true // Addition to actually split into multiple files
   }
})