### PR TITLE
Fix file extensions + add support for `ext` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ module.exports = {
       compileTranslations: { //optional
         input: 'po/*.po',
         outputFolder: 'l10n',
-        format: 'json'
+        format: 'javascript', // javascript or json
+        ext: 'js' // optional
       },
       extractStrings: { //optional
         input: 'app/**/*.html',

--- a/index.js
+++ b/index.js
@@ -20,13 +20,14 @@ function compile(options) {
     format: options.format
   });
 
+  const ext = options.format === 'javascript' ? 'js' : options.format;
   const filePaths = glob.sync(options.input)
   const outputs = filePaths.map( (filePath) => {
     const content = fs.readFileSync(filePath, options.encoding || 'utf-8');
     const fullFileName = path.basename(filePath);
     return {
       content: compiler.convertPo([content]),
-      fileName: path.basename(filePath, path.extname(fullFileName)) + '.' + options.format
+      fileName: path.basename(filePath, path.extname(fullFileName)) + '.' + (options.ext || ext)
     };
   } );
 


### PR DESCRIPTION
Fix file extension for `javascript` format and add support of `ext` option for `compileTranslations`