### PR TITLE
Fix: No output JSON/Javascript files generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,13 @@ AngularGetTextPlugin.prototype.apply = function(compiler) {
       const results = compile(options.compileTranslations);
       results.forEach( (result) => {
         const { fileName, content } = result;
+        var contentJSON = JSON.parse(content);
+        var unprefixedJSON = contentJSON[Object.keys(contentJSON)[0]];
+        if(!fs.existsSync(options.compileTranslations.outputFolder)){
+            fs.mkdirSync(options.compileTranslations.outputFolder, { recursive:true });
+        }
         const outPath = path.join(options.compileTranslations.outputFolder, fileName);
-	fs.writeFileSync(outPath, content);
+	fs.writeFileSync(outPath, JSON.stringify(unprefixedJSON));
         compilation.assets[outPath] = {
           source: function() {
             return content;

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ AngularGetTextPlugin.prototype.apply = function(compiler) {
       results.forEach( (result) => {
         const { fileName, content } = result;
         const outPath = path.join(options.compileTranslations.outputFolder, fileName);
+	fs.writeFileSync(outPath, content);
         compilation.assets[outPath] = {
           source: function() {
             return content;


### PR DESCRIPTION
Using the compileTranslations feature results in no output JSON / js files being generated.
This patch fixes that.